### PR TITLE
Last 30 days github data: PRs merged, created, and # contributors

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,6 +1,5 @@
 const path = require("path");
 const { graphql: github } = require("@octokit/graphql");
-const { exit } = require("process");
 
 exports.createPages = async ({ actions, graphql, reporter, cache }) => {
   const { createPage } = actions;

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -191,7 +191,7 @@ async function calculateGithubData(githubAPI, owner, repo) {
         }
       } else {
         // This PR is from more than a month ago.
-        // Since the data is sorted (by updated_at),
+        // Since the data is sorted (by created_at),
         // this PROBABLY means we have fetched all relevant data
         thereMayBeMoreCreatedData = false; // most likely
       }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -45,92 +45,11 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     let githubData = {};
 
     if (githubAPI) {
-      try {
-        let thereMayBeMoreData = true;
-        const data = await githubAPI(`
-        query mergedPRs($owner: String!, $repo: String!) {
-          repository(owner: $owner, name: $repo) {
-            pullRequests(first: 100, orderBy: {field: UPDATED_AT, direction: DESC}, states: MERGED) {
-              pageInfo {
-                startCursor
-                endCursor
-              }
-              totalCount
-              nodes {
-                createdAt
-                mergedAt
-                number
-                author {
-                  ... on Bot {
-                    id
-                  }
-                }
-              }
-            }
-          }
-          rateLimit {
-            cost,
-            remaining,
-            limit
-          }
-        }
-        `, {
-          owner: node.parent.relativeDirectory,
-          repo: node.parent.name,
-        });
-
-        const mergedThisMonth = data.repository.pullRequests.nodes.filter(({mergedAt, author}) => {
-          if (author?.id) {
-            return false;
-          }
-          const date = new Date(mergedAt);
-          const now = Date.now();
-          const isThisMonth = now - date < 30 /* days */ * 24 * 60 * 60 * 1000;
-          if (!isThisMonth) {
-            // This PR is from more than a month ago.
-            // Since the data is sorted (by updated_at),
-            // this PROBABLY means we have fetched all relevant data
-            thereMayBeMoreData = false; // most likely
-          }
-          
-          return isThisMonth;
-        });
-
-        githubData['prsMerged'] = {
-          count: mergedThisMonth.length,
-          maybeMore: thereMayBeMoreData
-        }
-
-        thereMayBeMoreData = true;
-
-        const createdThisMonth = data.repository.pullRequests.nodes.filter(({createdAt, author}) => {
-          // If author.id is set, this means that the author is a bot because specifically cast
-          // the author as a bot and get the id in the query.
-          if (author?.id) {
-            // TODO: Do we want to include bots?
-            return false;
-          }
-          const date = new Date(createdAt);
-          const now = Date.now();
-          const isThisMonth = now - date < 30 /* days */ * 24 * 60 * 60 * 1000;
-          if (!isThisMonth) {
-            // This PR is from more than a month ago.
-            // Since the data is sorted (by updated_at),
-            // this PROBABLY means we have fetched all relevant data
-            thereMayBeMoreData = false; // most likely
-          }
-          
-          return isThisMonth;
-        });
-
-        githubData['prsCreated'] = {
-          count: createdThisMonth.length,
-          maybeMore: thereMayBeMoreData
-        }
-
-      } catch (err) {
-        console.warn(err);
-      }
+      githubData = await calculateGithubData(
+        githubAPI, 
+        node.parent.relativeDirectory, 
+        node.parent.name
+      );
     }
 
     createPage({
@@ -146,26 +65,150 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
 };
 
 
-/*
-{
-  repository(name: "shipment-tracker", owner: "distributeaid") {
-    pullRequests(first: 100, orderBy: {field: UPDATED_AT, direction: DESC}, states: MERGED) {
-      pageInfo {
-        startCursor
-        endCursor
+
+async function calculateGithubData(githubAPI, owner, repo) {
+  let githubData = {};
+  try {
+    const mergedPRs = await githubAPI(`
+    query mergedPRs($owner: String!, $repo: String!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequests(first: 100, orderBy: {field: UPDATED_AT, direction: DESC}, states: MERGED) {
+          pageInfo {
+            startCursor
+            endCursor
+          }
+          totalCount
+          nodes {
+            createdAt
+            mergedAt
+            number
+            author {
+              ... on Bot {
+                botId: id
+              }
+              ... on User {
+                login
+              }
+            }
+    
+          }
+        }
       }
-      totalCount
-      nodes {
-        createdAt
-        mergedAt
-        number
+      rateLimit {
+        cost,
+        remaining,
+        limit
       }
     }
+    `, {
+      owner,
+      repo,
+    });
+
+
+    let mergedThisMonth = 0;
+    const contributorsThisMonth = new Set();
+    let thereMayBeMoreMergeData = true;
+
+    mergedPRs.repository.pullRequests.nodes.forEach(({mergedAt, author}) => {
+      // If author.botId is set, this means that the author is a bot because specifically cast
+      // the author as a bot and get the id in the query.
+      if (author?.botId) {
+        return false;
+      }
+      const date = new Date(mergedAt);
+      const now = Date.now();
+      const isThisMonth = now - date < 30 /* days */ * 24 * 60 * 60 * 1000;
+      if (isThisMonth) {
+        mergedThisMonth += 1;
+        if (author?.login) {
+          contributorsThisMonth.add(author.login);
+        }
+      } else {
+        // This PR is from more than a month ago.
+        // Since the data is sorted (by updated_at),
+        // this PROBABLY means we have fetched all relevant data
+        thereMayBeMoreMergeData = false; // most likely
+      }
+    });
+
+    githubData['prsMerged'] = {
+      count: mergedThisMonth,
+      maybeMore: thereMayBeMoreMergeData,
+    };
+
+    let thereMayBeMoreCreatedData = true;
+    const createdPRs = await githubAPI(`
+    query createdPRs($owner: String!, $repo: String!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequests(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {
+          pageInfo {
+            startCursor
+            endCursor
+          }
+          totalCount
+          nodes {
+            createdAt
+            mergedAt
+            number
+            author {
+              ... on Bot {
+                botId: id
+              }
+              ... on User {
+                login
+              }
+            }
+          }
+        }
+      }
+      rateLimit {
+        cost
+        remaining
+        limit
+      }
+    }        
+    `, {
+      owner,
+      repo,
+    });
+
+    let createdThisMonth = 0;
+    createdPRs.repository.pullRequests.nodes.forEach(({createdAt, author}) => {
+      // If author.botId is set, this means that the author is a bot because specifically cast
+      // the author as a bot and get the id in the query.
+      if (author?.botId) {
+        // TODO: Do we want to include bots?
+        return false;
+      }
+      const date = new Date(createdAt);
+      const now = Date.now();
+      const isThisMonth = now - date < 30 /* days */ * 24 * 60 * 60 * 1000;
+      if (isThisMonth) {
+        createdThisMonth += 1;
+        if (author?.login) {
+          contributorsThisMonth.add(author.login);
+        }
+      } else {
+        // This PR is from more than a month ago.
+        // Since the data is sorted (by updated_at),
+        // this PROBABLY means we have fetched all relevant data
+        thereMayBeMoreCreatedData = false; // most likely
+      }
+    });
+
+    githubData['prsCreated'] = {
+      count: createdThisMonth,
+      maybeMore: thereMayBeMoreCreatedData
+    }
+    githubData['contributors'] = {
+      count: contributorsThisMonth.size,
+      maybeMore: thereMayBeMoreMergeData || thereMayBeMoreCreatedData,
+    }
+
+  } catch (err) {
+    console.warn(err);
   }
-  rateLimit {
-    cost,
-    remaining,
-    limit
-  }
+
+  return githubData;
 }
- */

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const { graphql: github } = require("@octokit/graphql");
 
 exports.createPages = async ({ actions, graphql, reporter }) => {
   const { createPage } = actions;
@@ -26,15 +27,116 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     return;
   }
 
+  let githubAPI;
+  if (process.env.GITHUB_PERSONAL_ACCESS_TOKEN) {
+    githubAPI = github.defaults({
+      headers: {
+        authorization: `token ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`,
+      },
+    });  
+  }
+
   // Create a page for each project
-  projects.data.allMdx.nodes.forEach((node) => {
+  const nodes = projects.data.allMdx.nodes;
+  for (const node of nodes) {
+    let githubData = {};
+
+    if (githubAPI) {
+      try {
+        let thereMayBeMoreData = true;
+        const data = await githubAPI(`
+        query mergedPRs($owner: String!, $repo: String!) {
+          repository(owner: $owner, name: $repo) {
+            pullRequests(first: 100, orderBy: {field: UPDATED_AT, direction: DESC}, states: MERGED) {
+              pageInfo {
+                startCursor
+                endCursor
+              }
+              totalCount
+              nodes {
+                createdAt
+                mergedAt
+                number
+                author {
+                  ... on Bot {
+                    id
+                  }
+                }
+              }
+            }
+          }
+          rateLimit {
+            cost,
+            remaining,
+            limit
+          }
+        }
+        `, {
+          owner: node.parent.relativeDirectory,
+          repo: node.parent.name,
+        });
+
+        const mergedThisMonth = data.repository.pullRequests.nodes.filter(({mergedAt, author}) => {
+          if (author?.id) {
+            return false;
+          }
+          const date = new Date(mergedAt);
+          const now = Date.now();
+          const isThisMonth = now - date < 30 /* days */ * 24 * 60 * 60 * 1000;
+          if (!isThisMonth) {
+            // This PR is from more than a month ago.
+            // Since the data is sorted (by updated_at),
+            // this PROBABLY means we have fetched all relevant data
+            thereMayBeMoreData = false; // most likely
+          }
+          
+          return isThisMonth;
+        });
+
+        githubData = {
+          prsMerged: {
+            count: mergedThisMonth.length,
+            maybeMore: thereMayBeMoreData
+          }
+        }
+      } catch (err) {
+        console.warn(err);
+      }
+    }
+
     createPage({
       path: node.slug,
       component: projectTemplate,
       context: {
         id: node.id,
         slug: node.slug,
+        githubData,
       },
     });
-  });
+  }
 };
+
+
+/*
+{
+  repository(name: "shipment-tracker", owner: "distributeaid") {
+    pullRequests(first: 100, orderBy: {field: UPDATED_AT, direction: DESC}, states: MERGED) {
+      pageInfo {
+        startCursor
+        endCursor
+      }
+      totalCount
+      nodes {
+        createdAt
+        mergedAt
+        number
+      }
+    }
+  }
+  rateLimit {
+    cost,
+    remaining,
+    limit
+  }
+}
+ */

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@mdx-js/mdx": "1.6.22",
     "@mdx-js/react": "1.6.22",
     "@primer/octicons-react": "15.1.0",
+    "@octokit/graphql": "4.8.0",
     "algoliasearch": "4.10.5",
     "autoprefixer": "10.3.3",
     "classnames": "2.3.1",

--- a/src/templates/project.tsx
+++ b/src/templates/project.tsx
@@ -19,7 +19,7 @@ const mdxComponents = {
   Contributing,
 } as const;
 
-export default function ProjectTemplate({ data: { mdx } }) {
+export default function ProjectTemplate({ data: { mdx }, pageContext }) {
   return (
     <main className="max-w-4xl mx-auto py-12 px-2">
       <Helmet title={`OSS Port | ${mdx.frontmatter.name}`} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1535,6 +1535,57 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@octokit/endpoint@^6.0.1":
+  version "6.0.12"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.12.tgz#3b4d47a4b0e79b1027fb8d75d4221928b2d05658"
+  integrity sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    is-plain-object "^5.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/graphql@4.8.0":
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.8.0.tgz#664d9b11c0e12112cbf78e10f49a05959aa22cc3"
+  integrity sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==
+  dependencies:
+    "@octokit/request" "^5.6.0"
+    "@octokit/types" "^6.0.3"
+    universal-user-agent "^6.0.0"
+
+"@octokit/openapi-types@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-10.0.0.tgz#db4335de99509021f501fc4e026e6ff495fe1e62"
+  integrity sha512-k1iO2zKuEjjRS1EJb4FwSLk+iF6EGp+ZV0OMRViQoWhQ1fZTk9hg1xccZII5uyYoiqcbC73MRBmT45y1vp2PPg==
+
+"@octokit/request-error@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.1.0.tgz#9e150357831bfc788d13a4fd4b1913d60c74d677"
+  integrity sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
+"@octokit/request@^5.6.0":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.6.1.tgz#f97aff075c37ab1d427c49082fefeef0dba2d8ce"
+  integrity sha512-Ls2cfs1OfXaOKzkcxnqw5MR6drMA/zWX/LIS/p8Yjdz7QKTPQLMsB3R+OvoxE6XnXeXEE2X7xe4G4l4X0gRiKQ==
+  dependencies:
+    "@octokit/endpoint" "^6.0.1"
+    "@octokit/request-error" "^2.1.0"
+    "@octokit/types" "^6.16.1"
+    is-plain-object "^5.0.0"
+    node-fetch "^2.6.1"
+    universal-user-agent "^6.0.0"
+
+"@octokit/types@^6.0.3", "@octokit/types@^6.16.1":
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.26.0.tgz#b8af298485d064ad9424cb41520541c1bf820346"
+  integrity sha512-RDxZBAFMtqs1ZPnbUu1e7ohPNfoNhTiep4fErY7tZs995BeHu369Vsh5woMIaFbllRWEZBfvTCS4hvDnMPiHrA==
+  dependencies:
+    "@octokit/openapi-types" "^10.0.0"
+
 "@pmmmwh/react-refresh-webpack-plugin@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz#1eec460596d200c0236bf195b078a5d1df89b766"
@@ -3831,6 +3882,11 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
+deprecation@^2.0.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
+  integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
 destroy@~1.0.4:
   version "1.0.4"
@@ -6561,6 +6617,11 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
+
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
 is-promise@4.0.0:
   version "4.0.0"
@@ -10995,6 +11056,11 @@ unist-util-visit@^1.1.0, unist-util-visit@^1.4.1:
   integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
   dependencies:
     unist-util-visit-parents "^2.0.0"
+
+universal-user-agent@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
+  integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
We fetch data on count of merged PRs. Getting created PRs should be relatively easy.

We are not dealing with pagination right now, so sometimes there could be more data on the next page. We set a flag to say as much.

We must add a github personal access token (PAT) to the `.env` file for this to work, but if you don't set it, the build skips the github work.

```
GITHUB_PERSONAL_ACCESS_TOKEN=xxxxxx
```

The production token is in 1password, look for OSS Port Bot.