### PR TITLE
If totalCount <= 100, we know we have all the data

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -44,6 +44,8 @@ exports.createPages = async ({ actions, graphql, reporter, cache }) => {
         authorization: `token ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`,
       },
     });
+  } else {
+    console.warn("No GitHub API Token set, github data will not be available.");
   }
 
   // Create a page for each project

--- a/src/utils/calculateGithubData.js
+++ b/src/utils/calculateGithubData.js
@@ -77,7 +77,7 @@ async function calculateGithubData(githubAPI, owner, repo, cache) {
 
     let mergedThisMonth = 0;
     const contributorsThisMonth = new Set();
-    let thereMayBeMoreMergeData = true;
+    let thereMayBeMoreMergeData = mergedPRs.repository.pullRequests.totalCount > 100;
 
     mergedPRs.repository.pullRequests.nodes.forEach(({ mergedAt, author }) => {
       // If author.botId is set, this means that the author is a bot because specifically cast
@@ -106,7 +106,7 @@ async function calculateGithubData(githubAPI, owner, repo, cache) {
       maybeMore: thereMayBeMoreMergeData,
     };
 
-    let thereMayBeMoreCreatedData = true;
+
     const createdPRs = await githubAPI(
       `
     query createdPRs($owner: String!, $repo: String!) {
@@ -144,7 +144,8 @@ async function calculateGithubData(githubAPI, owner, repo, cache) {
         repo,
       }
     );
-
+    
+    let thereMayBeMoreCreatedData = createdPRs.repository.pullRequests.totalCount > 100;
     let createdThisMonth = 0;
     createdPRs.repository.pullRequests.nodes.forEach(
       ({ createdAt, author }) => {

--- a/src/utils/getCodeSeeMapMetadata.js
+++ b/src/utils/getCodeSeeMapMetadata.js
@@ -2,6 +2,7 @@ const axios = require("axios");
 const URL = require("url").URL;
 
 const codeseeAPIToken = process.env.CODESEE_API_TOKEN;
+let warned = false;
 
 async function getCodeSeeMapMetadata(mapUrl, cache) {
   // Figure out the map ID from its URL
@@ -23,12 +24,19 @@ async function getCodeSeeMapMetadata(mapUrl, cache) {
   const today = new Date().toISOString().substr(0, 10); // YYYY-MM-DD
   const cacheKey = `codesee:map:metadata:${mapId}:${today}`;
   const cached = await cache.get(cacheKey);
-  if (cached && !process.env.GITHUB_IGNORE_BUILD_CACHE) {
+  if (cached && !process.env.CODESEE_IGNORE_BUILD_CACHE) {
     return cached;
   }
 
   // If there's nothing in the cache, fetch the metadata from CodeSee
   if (mapId) {
+    if (!codeseeAPIToken) { 
+      if (!warned) {
+        console.warn("No Codesee API Token set, CodeSee Maps will not be rendered properly.");
+        warned = true;
+      }
+      return; 
+    }
     await axios
       .get(`https://app.codesee.io/api/maps/public/${mapId}/metadata`, {
         headers: { Authorization: `Bearer ${codeseeAPIToken}` },


### PR DESCRIPTION
NOTE: Also made CodeSee Map prep more resilient.

NOTE: CodeSee now has its own IGNORE CACHE flag: CODESEE_IGNORE_BUILD_CACHE

This PR removes the `+` on github data for OSS-Port project:
<img width="464" alt="Screen Shot 2021-09-03 at 3 35 58 PM" src="https://user-images.githubusercontent.com/334845/132072030-d8a05db2-5b2e-4ce8-85c2-f0ea9dae9c5d.png">
