### PR TITLE
Bring over project listing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,36 @@
 
 The map below is a good way to get familiar with the codebase:
 
-[<img src="docs/codebase-map.png" width="500">](https://app.codesee.io/maps/public/66e14ff0-0c28-11ec-83a7-234deb28a370)
+[<img alt="CodeSee Map preview" src="docs/codebase-map.png" width="500">](https://app.codesee.io/maps/public/66e14ff0-0c28-11ec-83a7-234deb28a370)
+
+
+### How to list your own project
+
+1. Follow the above setup steps
+1. Take a peek inside the `/projects` directory for examples of existing repo
+1. Create a new folder inside `/projects` and name it the same as your GitHub organization
+1. Add a new `.mdx` file using the name of your repo
+1. Copy/paste the contents of `src/templates/repoTemplate.mdx` into that file
+1. Fill out the information. Note that most of it is optional, but extremely helpful for potential contributors.
+1. Add a 400x400 image for your organisation to your folder. For example, `./projects/distributeaid/da.png`
+1. Preview your changes locally.
+1. When you're ready, open a PR!
+
+### Adding a CodeSee Map to your project listing
+
+With a CodeSee Map, you can monumentally improve the onboarding experience for contributors to your project!
+
+To add a Map to your project:
+
+1. Sign up for [CodeSee Maps](https://codesee.io) (free!)
+1. Create a Map for your repo following [our instructions](https://docs.codesee.io/en/latest/)
+1. Add an entry in your project's template for the Map (example from Distribute Aid's Shipment Tracker project):
+
+```
+featuredMap:
+  url: https://app.codesee.io/maps/public/b7367890-0129-11ec-a91a-57f039601939
+  description: Get a quick overview of the major areas of our repo
+```
 
 ### Notes
 


### PR DESCRIPTION
This brings over the instructions to add a project (Thank you so much for writing these, @deammer!) to the README, along with Map setup instructions