### PR TITLE
Display placeholder GitHub stats when the API token is missing

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,5 @@
 # The API token used to fetch Map metadata (optional)
 CODESEE_API_TOKEN
+
+# An API token used to fetch GitHub stats (optional)
+GITHUB_PERSONAL_ACCESS_TOKEN

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -95,7 +95,7 @@ const ProjectCard: FunctionComponent<Props> = ({
       </div>
       <div>
         <hr className="border-black-50 -ml-4 -mr-4 mt-2" />
-        {githubData && <RepoStats className="mt-4" stats={githubData} />}
+        <RepoStats className="mt-4" stats={githubData} />
       </div>
     </div>
   );

--- a/src/components/RepoStats.tsx
+++ b/src/components/RepoStats.tsx
@@ -2,9 +2,7 @@ import { InfoIcon } from "@primer/octicons-react";
 import React, { FunctionComponent } from "react";
 import { GitHubMetric } from "../types";
 
-const STATS_ARE_MISSING =
-  process.env.NODE_ENV !== "production" &&
-  process.env.GITHUB_PERSONAL_ACCESS_TOKEN == null;
+const STATS_ARE_MISSING = process.env.NODE_ENV !== "production";
 
 type Props = {
   className?: string;

--- a/src/components/RepoStats.tsx
+++ b/src/components/RepoStats.tsx
@@ -1,9 +1,14 @@
+import { InfoIcon } from "@primer/octicons-react";
 import React, { FunctionComponent } from "react";
 import { GitHubMetric } from "../types";
 
+const STATS_ARE_MISSING =
+  process.env.NODE_ENV !== "production" &&
+  process.env.GITHUB_PERSONAL_ACCESS_TOKEN == null;
+
 type Props = {
   className?: string;
-  stats: {
+  stats?: {
     prsCreated: GitHubMetric;
     prsMerged: GitHubMetric;
     contributors: GitHubMetric;
@@ -11,6 +16,10 @@ type Props = {
 };
 
 function formatMetric(metric: GitHubMetric) {
+  if (metric == null) {
+    return "0";
+  }
+
   if (metric.maybeMore) {
     if (metric.count > 20) {
       return Math.floor(metric.count / 10) * 10 + "+";
@@ -28,7 +37,7 @@ const RepoStats: FunctionComponent<Props> = ({ stats, className }) => {
       <div className="flex justify-between text-black-500 space-x-4 text-center">
         <div>
           <div className="text-2xl font-bold">
-            {formatMetric(stats.prsCreated)}
+            {formatMetric(stats?.prsCreated)}
           </div>
           <small className="text-black-400 text-xs uppercase whitespace-nowrap">
             PRs opened
@@ -36,7 +45,7 @@ const RepoStats: FunctionComponent<Props> = ({ stats, className }) => {
         </div>
         <div>
           <div className="text-2xl font-bold">
-            {formatMetric(stats.prsMerged)}
+            {formatMetric(stats?.prsMerged)}
           </div>
           <small className="text-black-400 text-xs uppercase whitespace-nowrap">
             PRs merged
@@ -44,13 +53,22 @@ const RepoStats: FunctionComponent<Props> = ({ stats, className }) => {
         </div>
         <div>
           <div className="text-2xl font-bold">
-            {formatMetric(stats.contributors)}
+            {formatMetric(stats?.contributors)}
           </div>
           <small className="text-black-400 text-xs uppercase whitespace-nowrap">
             Contributors
           </small>
         </div>
       </div>
+      {STATS_ARE_MISSING && (
+        <div
+          title="This text is only visible during local development"
+          className="mt-2 text-xs flex items-center text-gray-400"
+        >
+          <InfoIcon size={12} className="mr-1" />
+          GitHub stats will appear during Netlify builds
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
GitHub stats require a personal access token. If it doesn't exist, the site should work just fine.

<img width="380" alt="Screen Shot 2021-09-10 at 12 26 26 PM" src="https://user-images.githubusercontent.com/3411183/132907054-25c7b23a-2855-4e42-9793-f5ea9f2071b7.png">
