### PR TITLE
Add empty search results slate

### DIFF
--- a/src/components/local-search/LocalSearch.tsx
+++ b/src/components/local-search/LocalSearch.tsx
@@ -90,6 +90,16 @@ const LocalSearch: FunctionComponent<Props> = ({
           />
         ))}
       </ProjectListWrapper>
+      {filteredProjects.length === 0 && (
+        <div className="text-center px-4">
+          <h3 className="text-black-500 text-2xl font-semibold mb-4">
+            No results
+          </h3>
+          <p className="text-black-300">
+            No projects matched your search. Try adjusting your filters.
+          </p>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
<img width="846" alt="Screen Shot 2021-09-13 at 10 01 53 AM" src="https://user-images.githubusercontent.com/3411183/133126198-a945966a-442f-439b-89d2-458c45217cf5.png">
