### PR TITLE
Moving and renaming the repoTemplate file to be easier to find

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -5,9 +5,9 @@ Before continuing, please make sure you read and abide by our [Code of Conduct](
 In order to make sure we accept your project as soon as possible, please make sure to fulfill everything on the following list:
 
 - [ ] Create a folder for your organisation in the `projects` folder. For example, `./projects/distributeaid`
-- [ ] Copy [this template](../../src/templates/repoTemplate.mdx) into in the `projects` folder and name it after your project. For example, `./projects/distributeaid/shipment-tracker.mdx`
+- [ ] Copy [this template](../../projects/_template.mdx) into in the `projects` folder and name it after your project. For example, `./projects/distributeaid/shipment-tracker.mdx`
 - [ ] Fill out your project's details in the file metadata
-- [ ] Add a 400x400 image for your organisation to your folder. For example, `./projects/distributeaid/da.png`
+- [ ] Add a 200x200 image for your organisation to your folder. For example, `./projects/distributeaid/da.png`
 
 ## Adding a CodeSee Map to your project listing
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,12 @@ The CodeSee Map below is a good way to get familiar with the codebase:
 
 [<img alt="CodeSee Map preview" src="docs/codebase-map.png" width="500">](https://app.codesee.io/maps/public/66e14ff0-0c28-11ec-83a7-234deb28a370)
 
-
 ### How to list your own project
 
 1. Follow the above setup steps
 1. Create a new folder inside `/projects` and name it the same as your GitHub handle or organization
 1. Add a new `.mdx` file using the name of your public repo
-1. Copy/paste the contents of `src/templates/repoTemplate.mdx` into that file
+1. Copy/paste the contents of `projects/_template.mdx` into that file
 1. Fill out the information — most of it is optional, but extremely helpful for potential contributors. If you opt not to include the optional content, delete it from your template.
 1. Add a 200x200 image for your organization to your folder, for example, `./projects/distributeaid/da.png`
 1. Preview your changes locally
@@ -40,7 +39,6 @@ The CodeSee Map below is a good way to get familiar with the codebase:
 ### Adding a CodeSee Map to your project listing
 
 Make it easier for contributors to onboard to your project! With a CodeSee Map, they can visualize the entire codebase, with features allowing them to explore system dependencies, add additional context to pull requests, and more.
-
 
 To add a Map to your project:
 
@@ -55,6 +53,7 @@ featuredMap:
 ```
 
 ### How to remove your project from OSS Port
+
 Open a PR to remove your project folder from this repository.
 
 ### Notes

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The CodeSee Map below is a good way to get familiar with the codebase:
 1. Follow the above setup steps
 1. Create a new folder inside `/projects` and name it the same as your GitHub handle or organization
 1. Add a new `.mdx` file using the name of your public repo
-1. Copy/paste the contents of `projects/_template.mdx` into that file
+1. Copy/paste the contents of [`projects/_template.mdx`](https://raw.githubusercontent.com/Codesee-io/oss-port/main/projects/_template.mdx) into that file
 1. Fill out the information — most of it is optional, but extremely helpful for potential contributors. If you opt not to include the optional content, delete it from your template.
 1. Add a 200x200 image for your organization to your folder, for example, `./projects/distributeaid/da.png`
 1. Preview your changes locally

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -30,6 +30,7 @@ module.exports = {
       options: {
         name: "projects",
         path: "./projects",
+        ignore: ["**/_template.mdx"],
       },
     },
     {

--- a/projects/Codesee-io/oss-port.mdx
+++ b/projects/Codesee-io/oss-port.mdx
@@ -46,7 +46,7 @@ At this stage, we're mainly looking for contributions from **project maintainers
 1. Take a peek inside the `/projects` directory for examples of existing repo
 1. Create a new folder inside `/projects` and name it the same as your GitHub organization
 1. Add a new `.mdx` file using the name of your repo
-1. Copy/paste the contents of `src/templates/repoTemplate.mdx` into that file
+1. Copy/paste the contents of `projects/_template.mdx` into that file
 1. Fill out the information. Note that most of it is optional, but extremely helpful for potential contributors.
 1. Preview your changes locally.
 1. When you're ready, open a PR!

--- a/projects/_template.mdx
+++ b/projects/_template.mdx
@@ -12,7 +12,7 @@ tags: # A list of programming languages and keywords relevant to the contributor
   - Social Activism
   - JavaScript
   - Python
-  - C / C++ 
+  - C / C++
   - C#
   - Swift
   - Objective C
@@ -23,7 +23,7 @@ tags: # A list of programming languages and keywords relevant to the contributor
   - Rust
   - Ruby
   - HTML / CSS
-  - (you may add custom entries, but please also add them to the canonical list in repoTemplate.mdx)
+  - (you may add custom entries, but please also add them to the canonical list in projects/_template.mdx)
 avatar: (optional) The name of an image in the project's directory, like "avatar.png". This will appear on the project card contributors see when searching for a project.
 websiteUrl: (optional) Website for the project or organization
 twitterUrl: (optional) URL to the organization or project's Twitter page
@@ -34,7 +34,7 @@ currentlySeeking: # (optional) These fields are searchable and very helpful for 
   - Code Reviewers
   - Technical Writers
   - Mentors
-  - (you may add custom entries, but please also add them to the canonical list in repoTemplate.mdx)
+  - (you may add custom entries, but please also add them to the canonical list in project/_template.mdx)
 featuredMap: # (optional) A CodeSee Map to serve as a visual starting point for contributors
   url: https://app.codesee.io/maps/public/66e14ff0-0c28-11ec-83a7-234deb28a370
   description: (optional) short description of the CodeSee Map
@@ -59,7 +59,6 @@ Introduce your project to potential contributors!
 **Hint:** you can write GitHub-flavored markdown just like you're used to.
 
 </Overview>
-
 
 <Contributing>
 


### PR DESCRIPTION
the template our repo maintainers need to copy is now right in the projects folder so its easy to find and wont get mixed up with the other things in src/templates/