### PR TITLE
fix: use @media to ignore hover css on mobile

### DIFF
--- a/src/components/CallToAction.tsx
+++ b/src/components/CallToAction.tsx
@@ -6,7 +6,7 @@ const CallToAction: FunctionComponent<AnchorHTMLAttributes<HTMLAnchorElement>> =
     return (
       <a
         className={cx(
-          "bg-yellow-200 text-black-500 hover:bg-yellow-300 rounded px-8 py-2 font-semibold",
+          "bg-yellow-200 text-black-500 hover-hover:hover:bg-yellow-300 rounded px-8 py-2 font-semibold",
           className
         )}
         {...otherProps}

--- a/src/components/CallToAction.tsx
+++ b/src/components/CallToAction.tsx
@@ -6,7 +6,7 @@ const CallToAction: FunctionComponent<AnchorHTMLAttributes<HTMLAnchorElement>> =
     return (
       <a
         className={cx(
-          "bg-yellow-200 text-black-500 hover-hover:hover:bg-yellow-300 rounded px-8 py-2 font-semibold",
+          "bg-yellow-200 text-black-500 supports-hover:hover:bg-yellow-300 rounded px-8 py-2 font-semibold",
           className
         )}
         {...otherProps}

--- a/src/components/ClickableTag.tsx
+++ b/src/components/ClickableTag.tsx
@@ -15,7 +15,7 @@ const ClickableTag: FunctionComponent<Props> = ({ tag, onClick, isActive }) => {
       className={cx(
         "inline-block border rounded-md px-2 py-1 text-xs text-black-400",
         {
-          "border-black-100 hover-hover:hover:bg-blue-500 hover-hover:hover:border-blue-500 hover-hover:hover:text-white":
+          "border-black-100 supports-hover:hover:bg-blue-500 supports-hover:hover:border-blue-500 supports-hover:hover:text-white":
             !isActive,
           "border-blue-700 bg-blue-700 text-white": isActive,
         }

--- a/src/components/ClickableTag.tsx
+++ b/src/components/ClickableTag.tsx
@@ -15,7 +15,7 @@ const ClickableTag: FunctionComponent<Props> = ({ tag, onClick, isActive }) => {
       className={cx(
         "inline-block border rounded-md px-2 py-1 text-xs text-black-400",
         {
-          "border-black-100 hover:bg-blue-500 hover:border-blue-500 hover:text-white":
+          "border-black-100 hover-hover:hover:bg-blue-500 hover-hover:hover:border-blue-500 hover-hover:hover:text-white":
             !isActive,
           "border-blue-700 bg-blue-700 text-white": isActive,
         }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,7 +6,7 @@ const Footer: FunctionComponent = () => (
     <p className="text-sm text-center flex items-center justify-center">
       Built with tea and love by{" "}
       <a
-        className="opacity-75 hover:opacity-100 ml-1"
+        className="opacity-75 hover-hover:hover:opacity-100 ml-1"
         href="https://www.codesee.io"
         target="_blank"
         rel="noopener"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,7 +6,7 @@ const Footer: FunctionComponent = () => (
     <p className="text-sm text-center flex items-center justify-center">
       Built with tea and love by{" "}
       <a
-        className="opacity-75 hover-hover:hover:opacity-100 ml-1"
+        className="opacity-75 supports-hover:hover:opacity-100 ml-1"
         href="https://www.codesee.io"
         target="_blank"
         rel="noopener"

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -43,7 +43,7 @@ const ProjectCard: FunctionComponent<Props> = ({
           </div>
         )}
         <h3 className="font-bold text-black-500 pl-8">
-          <Link to={slug} className="hover-hover:hover:text-blue-400">
+          <Link to={slug} className="supports-hover:hover:text-blue-400">
             {frontmatter.name}
           </Link>
         </h3>
@@ -69,7 +69,7 @@ const ProjectCard: FunctionComponent<Props> = ({
             target="_blank"
             title="Visit this repository"
             rel="noopener"
-            className="text-black-300 hover-hover:hover:text-blue-400 p-1"
+            className="text-black-300 supports-hover:hover:text-blue-400 p-1"
           >
             <MarkGithubIcon size={20} />
           </a>
@@ -82,7 +82,7 @@ const ProjectCard: FunctionComponent<Props> = ({
                 "View this project's CodeSee map"
               }
               rel="noopener"
-              className="text-black-300 hover-hover:hover:text-blue-400 p-1"
+              className="text-black-300 supports-hover:hover:text-blue-400 p-1"
             >
               <MapIcon width={20} />
             </a>
@@ -93,7 +93,7 @@ const ProjectCard: FunctionComponent<Props> = ({
               target="_blank"
               title="Visit this project's website"
               rel="noopener"
-              className="text-black-300 hover-hover:hover:text-blue-400 p-1"
+              className="text-black-300 supports-hover:hover:text-blue-400 p-1"
             >
               <LinkIcon size={20} />
             </a>
@@ -104,7 +104,7 @@ const ProjectCard: FunctionComponent<Props> = ({
               target="_blank"
               title="Visit this project's Twitter feed"
               rel="noopener"
-              className="text-black-300 hover-hover:hover:text-blue-400 p-1"
+              className="text-black-300 supports-hover:hover:text-blue-400 p-1"
             >
               <TwitterIcon />
             </a>

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -43,7 +43,7 @@ const ProjectCard: FunctionComponent<Props> = ({
           </div>
         )}
         <h3 className="font-bold text-black-500 pl-8">
-          <Link to={slug} className="hover:text-blue-400">
+          <Link to={slug} className="hover-hover:hover:text-blue-400">
             {frontmatter.name}
           </Link>
         </h3>
@@ -69,7 +69,7 @@ const ProjectCard: FunctionComponent<Props> = ({
             target="_blank"
             title="Visit this repository"
             rel="noopener"
-            className="text-black-300 hover:text-blue-400 p-1"
+            className="text-black-300 hover-hover:hover:text-blue-400 p-1"
           >
             <MarkGithubIcon size={20} />
           </a>
@@ -82,7 +82,7 @@ const ProjectCard: FunctionComponent<Props> = ({
                 "View this project's CodeSee map"
               }
               rel="noopener"
-              className="text-black-300 hover:text-blue-400 p-1"
+              className="text-black-300 hover-hover:hover:text-blue-400 p-1"
             >
               <MapIcon width={20} />
             </a>
@@ -93,7 +93,7 @@ const ProjectCard: FunctionComponent<Props> = ({
               target="_blank"
               title="Visit this project's website"
               rel="noopener"
-              className="text-black-300 hover:text-blue-400 p-1"
+              className="text-black-300 hover-hover:hover:text-blue-400 p-1"
             >
               <LinkIcon size={20} />
             </a>
@@ -104,7 +104,7 @@ const ProjectCard: FunctionComponent<Props> = ({
               target="_blank"
               title="Visit this project's Twitter feed"
               rel="noopener"
-              className="text-black-300 hover:text-blue-400 p-1"
+              className="text-black-300 hover-hover:hover:text-blue-400 p-1"
             >
               <TwitterIcon />
             </a>

--- a/src/components/ProjectTabs.tsx
+++ b/src/components/ProjectTabs.tsx
@@ -17,7 +17,7 @@ const Tab: FunctionComponent<TabProps> = ({ children, isActive, href }) => {
         "text-black-500 px-3 py-1 inline-flex items-center border-b-2 border-transparent -mb-px",
         {
           "border-black-500 font-semibold": isActive,
-          "hover:border-blue-500": !isActive,
+          "hover-hover:hover:border-blue-500": !isActive,
         }
       )}
     >

--- a/src/components/ProjectTabs.tsx
+++ b/src/components/ProjectTabs.tsx
@@ -17,7 +17,7 @@ const Tab: FunctionComponent<TabProps> = ({ children, isActive, href }) => {
         "text-black-500 px-3 py-1 inline-flex items-center border-b-2 border-transparent -mb-px",
         {
           "border-black-500 font-semibold": isActive,
-          "hover-hover:hover:border-blue-500": !isActive,
+          "supports-hover:hover:border-blue-500": !isActive,
         }
       )}
     >

--- a/src/components/RepoLinks.tsx
+++ b/src/components/RepoLinks.tsx
@@ -15,7 +15,7 @@ const RepoLinks: FunctionComponent<Props> = ({ frontmatter }) => {
       <div className="flex space-x-4 mb-8">
         <a
           target="_blank"
-          className="text-black-300 hover-hover:hover:text-blue-400"
+          className="text-black-300 supports-hover:hover:text-blue-400"
           href={frontmatter.repoUrl}
           title="Visit this repository on GitHub"
         >
@@ -24,7 +24,7 @@ const RepoLinks: FunctionComponent<Props> = ({ frontmatter }) => {
         {frontmatter.featuredMap?.url && (
           <a
             target="_blank"
-            className="text-black-300 hover-hover:hover:text-blue-400"
+            className="text-black-300 supports-hover:hover:text-blue-400"
             href={frontmatter.featuredMap.url}
             title={
               frontmatter.featuredMap.description ||
@@ -37,7 +37,7 @@ const RepoLinks: FunctionComponent<Props> = ({ frontmatter }) => {
         {frontmatter.twitterUrl && (
           <a
             target="_blank"
-            className="text-black-300 hover-hover:hover:text-blue-400"
+            className="text-black-300 supports-hover:hover:text-blue-400"
             href={frontmatter.twitterUrl}
             title="Connect with this community on Twitter"
           >
@@ -47,7 +47,7 @@ const RepoLinks: FunctionComponent<Props> = ({ frontmatter }) => {
         {frontmatter.websiteUrl && (
           <a
             target="_blank"
-            className="text-black-300 hover-hover:hover:text-blue-400"
+            className="text-black-300 supports-hover:hover:text-blue-400"
             href={frontmatter.websiteUrl}
             title="Visit this project's website"
           >

--- a/src/components/RepoLinks.tsx
+++ b/src/components/RepoLinks.tsx
@@ -15,7 +15,7 @@ const RepoLinks: FunctionComponent<Props> = ({ frontmatter }) => {
       <div className="flex space-x-4 mb-8">
         <a
           target="_blank"
-          className="text-black-300 hover:text-blue-400"
+          className="text-black-300 hover-hover:hover:text-blue-400"
           href={frontmatter.repoUrl}
           title="Visit this repository on GitHub"
         >
@@ -24,7 +24,7 @@ const RepoLinks: FunctionComponent<Props> = ({ frontmatter }) => {
         {frontmatter.featuredMap?.url && (
           <a
             target="_blank"
-            className="text-black-300 hover:text-blue-400"
+            className="text-black-300 hover-hover:hover:text-blue-400"
             href={frontmatter.featuredMap.url}
             title={
               frontmatter.featuredMap.description ||
@@ -37,7 +37,7 @@ const RepoLinks: FunctionComponent<Props> = ({ frontmatter }) => {
         {frontmatter.twitterUrl && (
           <a
             target="_blank"
-            className="text-black-300 hover:text-blue-400"
+            className="text-black-300 hover-hover:hover:text-blue-400"
             href={frontmatter.twitterUrl}
             title="Connect with this community on Twitter"
           >
@@ -47,7 +47,7 @@ const RepoLinks: FunctionComponent<Props> = ({ frontmatter }) => {
         {frontmatter.websiteUrl && (
           <a
             target="_blank"
-            className="text-black-300 hover:text-blue-400"
+            className="text-black-300 hover-hover:hover:text-blue-400"
             href={frontmatter.websiteUrl}
             title="Visit this project's website"
           >

--- a/src/components/markdown/FeaturedCodeSeeMap.tsx
+++ b/src/components/markdown/FeaturedCodeSeeMap.tsx
@@ -30,7 +30,7 @@ const FeaturedCodeSeeMap: FunctionComponent = () => {
       <div className="sm:pl-8 mt-6 sm:mt-0 text-black-500">
         <a
           href={frontmatter.featuredMap.url}
-          className="font-bold text-lg hover:text-blue-500 leading-4 mb-2"
+          className="font-bold text-lg hover-hover:hover:text-blue-500 leading-4 mb-2"
         >
           {featuredMapMetadata.name}
         </a>

--- a/src/components/markdown/FeaturedCodeSeeMap.tsx
+++ b/src/components/markdown/FeaturedCodeSeeMap.tsx
@@ -30,7 +30,7 @@ const FeaturedCodeSeeMap: FunctionComponent = () => {
       <div className="sm:pl-8 mt-6 sm:mt-0 text-black-500">
         <a
           href={frontmatter.featuredMap.url}
-          className="font-bold text-lg hover-hover:hover:text-blue-500 leading-4 mb-2"
+          className="font-bold text-lg supports-hover:hover:text-blue-500 leading-4 mb-2"
         >
           {featuredMapMetadata.name}
         </a>

--- a/src/components/markdown/IssueList.tsx
+++ b/src/components/markdown/IssueList.tsx
@@ -41,7 +41,7 @@ const IssueList: FunctionComponent<Props> = ({
             <a
               href={issue.url}
               target="_blank"
-              className="ml-2 font-semibold hover:text-blue-500"
+              className="ml-2 font-semibold hover-hover:hover:text-blue-500"
             >
               {issue.title}
             </a>
@@ -53,7 +53,7 @@ const IssueList: FunctionComponent<Props> = ({
           <a
             href={getLabelUrl(repoUrl, label)}
             target="_blank"
-            className="text-sm font-bold hover:text-blue-500"
+            className="text-sm font-bold hover-hover:hover:text-blue-500"
             rel="noreferrer"
           >
             View all

--- a/src/components/markdown/IssueList.tsx
+++ b/src/components/markdown/IssueList.tsx
@@ -41,7 +41,7 @@ const IssueList: FunctionComponent<Props> = ({
             <a
               href={issue.url}
               target="_blank"
-              className="ml-2 font-semibold hover-hover:hover:text-blue-500"
+              className="ml-2 font-semibold supports-hover:hover:text-blue-500"
             >
               {issue.title}
             </a>
@@ -53,7 +53,7 @@ const IssueList: FunctionComponent<Props> = ({
           <a
             href={getLabelUrl(repoUrl, label)}
             target="_blank"
-            className="text-sm font-bold hover-hover:hover:text-blue-500"
+            className="text-sm font-bold supports-hover:hover:text-blue-500"
             rel="noreferrer"
           >
             View all

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -52,7 +52,7 @@ module.exports = {
         "black-200": theme("colors.black.200"),
       }),
       screens: {
-        'hover-hover': {'raw': '(hover: hover)'},
+        'supports-hover': {'raw': '(hover: hover)'},
       }
     },
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -51,6 +51,9 @@ module.exports = {
       fill: (theme) => ({
         "black-200": theme("colors.black.200"),
       }),
+      screens: {
+        'hover-hover': {'raw': '(hover: hover)'},
+      }
     },
   },
   variants: {


### PR DESCRIPTION
Hi there!

I was checking this out on my phone and noticed a small UI bug - the hover state is 'sticky' e.g. if you touch a tag it keeps the hover state until you click elsewhere:

![Sticky](https://user-images.githubusercontent.com/15801806/133600578-22504a3a-7f36-46cf-b4a0-eca5ed7ce943.gif)

with this PR's changes:

![Unstuck](https://user-images.githubusercontent.com/15801806/133600622-29cb5df0-865a-489b-9e53-be66af5db0d2.gif)

I'm very new to Tailwind and the best I could come up with was the rather ugly `hover-hover:hover` classes.  If there's a nicer way, it eluded me.