### PR TITLE
feat: add contributing docs to freecodecamp

### DIFF
--- a/projects/freeCodeCamp/freeCodeCamp.mdx
+++ b/projects/freeCodeCamp/freeCodeCamp.mdx
@@ -39,7 +39,7 @@ The freeCodeCamp.org community is possible thanks to thousands of kind volunteer
 - Help by answering coding questions on our community forum.
 - Give feedback on coding projects built by campers.
 - Help us translate freeCodeCamp.org's resources.
-- Contribute to our open source codebase on GitHub.
+- [Contribute](https://contribute.freecodecamp.org/#/) to our open source codebase on GitHub.
 
 The general platform status for all our applications is available at status.freecodecamp.org. The build and deployment status for the code is available in our DevOps Guide.
 


### PR DESCRIPTION
Hello CodeSee!

To assist in users being directed to the correct contributing documentation, a link is added.

Feel free to close, if unwanted.