### PR TITLE
Add support for emojis in MDX files

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,4 @@
-require("dotenv").config();
+const emoji = require("remark-emoji");
 
 module.exports = {
   siteMetadata: {
@@ -38,6 +38,7 @@ module.exports = {
       resolve: "gatsby-plugin-mdx",
       options: {
         extensions: [".md", ".mdx"],
+        remarkPlugins: [emoji],
       },
     },
   ],

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "autoprefixer": "10.3.3",
     "axios": "0.21.2",
     "classnames": "2.3.1",
-    "dotenv": "10.0.0",
     "gatsby": "3.13.0",
     "gatsby-plugin-image": "1.13.0",
     "gatsby-plugin-manifest": "3.13.0",
@@ -41,6 +40,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-helmet": "6.1.0",
+    "remark-emoji": "2.2.0",
     "tailwindcss": "2.2.9"
   },
   "devDependencies": {

--- a/projects/_template.mdx
+++ b/projects/_template.mdx
@@ -64,7 +64,7 @@ learnLinks: # (optional) A list of links to support new contributors in learning
 
 Introduce your project to potential contributors!
 
-**Hint:** you can write GitHub-flavored markdown just like you're used to.
+**Hint:** you can write GitHub-flavored markdown just like you're used to. We even support Slack-style emojis :v:
 
 </Overview>
 

--- a/src/templates/ProjectTemplate.tsx
+++ b/src/templates/ProjectTemplate.tsx
@@ -71,9 +71,9 @@ const ProjectTemplate: FunctionComponent<ProjectTemplateProps> = ({
             <h1 className="mt-2 mb-4 text-black-500 font-bold text-4xl font-accent">
               {projectData.frontmatter.name}
             </h1>
-            <div className="space-x-2 mb-4">
+            <div className="mb-4">
               {badges.map((badge) => (
-                <Tag key={badge} tag={badge} />
+                <Tag key={badge} tag={badge} className="mr-2 mb-2" />
               ))}
             </div>
             <div className="md:flex mb-6">

--- a/yarn.lock
+++ b/yarn.lock
@@ -5075,11 +5075,6 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
-dotenv@10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
-  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
-
 dotenv@^8.2.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
@@ -5129,6 +5124,11 @@ emojis-list@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
+
+emoticon@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/emoticon/-/emoticon-3.2.0.tgz#c008ca7d7620fac742fe1bf4af8ff8fed154ae7f"
+  integrity sha512-SNujglcLTTg+lDAcApPNgEdudaqQFiAbJCqzjNxJkvN9vAwCGi0uu8IUVvx+f16h+V44KCY6Y2yboroc9pilHg==
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -9697,7 +9697,7 @@ node-addon-api@^4.1.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.1.0.tgz#f1722f1f60793584632ffffb79e12ca042c48bd0"
   integrity sha512-Zz1o1BDX2VtduiAt6kgiUl8jX1Vm3NMboljFYKQJ6ee8AGfiTvM2mlZFI3xPbqjs80rCQgiVJI/DjQ/1QJ0HwA==
 
-node-emoji@^1.11.0:
+node-emoji@^1.10.0, node-emoji@^1.11.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.11.0.tgz#69a0150e6946e2f115e9d7ea4df7971e2628301c"
   integrity sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==
@@ -11356,6 +11356,15 @@ regjsparser@^0.6.4:
   integrity sha512-ZqbNRz1SNjLAiYuwY0zoXW8Ne675IX5q+YHioAGbCw4X96Mjl2+dcX9B2ciaeyYjViDAfvIjFpQjJgLttTEERQ==
   dependencies:
     jsesc "~0.5.0"
+
+remark-emoji@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/remark-emoji/-/remark-emoji-2.2.0.tgz#1c702090a1525da5b80e15a8f963ef2c8236cac7"
+  integrity sha512-P3cj9s5ggsUvWw5fS2uzCHJMGuXYRb0NnZqYlNecewXt8QBU9n5vW3DUUKOhepS8F9CwdMx9B8a3i7pqFWAI5w==
+  dependencies:
+    emoticon "^3.2.0"
+    node-emoji "^1.10.0"
+    unist-util-visit "^2.0.3"
 
 remark-footnotes@2.0.0:
   version "2.0.0"
@@ -13276,7 +13285,7 @@ unist-util-visit-parents@^3.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
 
-unist-util-visit@2.0.3, unist-util-visit@^2.0.0, unist-util-visit@^2.0.2:
+unist-util-visit@2.0.3, unist-util-visit@^2.0.0, unist-util-visit@^2.0.2, unist-util-visit@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-2.0.3.tgz#c3703893146df47203bb8a9795af47d7b971208c"
   integrity sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==


### PR DESCRIPTION
At least 2 maintainers have added Slack-style emojis to their content, so I figured we should display them properly `:rocket:`

<img width="726" alt="Screen Shot 2021-09-17 at 12 41 55 PM" src="https://user-images.githubusercontent.com/3411183/133844774-ebd6445c-1703-41c7-b30a-e78c90b81208.png">
