### PR TITLE
fix: add trailing slash to avoid about 301

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,7 +12,7 @@ const Header: FunctionComponent = () => {
         </Link>
         <div className="flex items-center justify-center">
           <div className="hidden sm:block">
-            <a href="/about" style={{color:"white", marginRight: "20px"}}>
+            <a href="/about/" style={{color:"white", marginRight: "20px"}}>
               About
             </a>
           </div>


### PR DESCRIPTION
Hey :wave:  

I noticed
![image](https://user-images.githubusercontent.com/15801806/134325094-9815b6e2-cb56-4b6c-b045-a63333731c1b.png)

so here's a tiny PR to speed things up a smidge.