### PR TITLE
Remove OSS port default map from projects

### DIFF
--- a/projects/distributeaid/shipment-tracker.mdx
+++ b/projects/distributeaid/shipment-tracker.mdx
@@ -15,9 +15,6 @@ contributionOverview:
   idealEffort: 2 PRs a month
   isMentorshipAvailable: true
 avatar: da.png
-featuredMap:
-  url: https://app.codesee.io/maps/public/848e3630-1650-11ec-8bc1-7d4a4822cc27
-  description: Get a quick overview of the major areas of our repo
 ---
 
 <Overview>

--- a/projects/roerohan/react-vnc.mdx
+++ b/projects/roerohan/react-vnc.mdx
@@ -17,9 +17,6 @@ currentlySeeking: # (optional) These fields are searchable and very helpful for 
   - Designers
   - Maintainers
   - Code Reviewers
-featuredMap: # (optional) A CodeSee Map to serve as a visual starting point for contributors
-  url: https://app.codesee.io/maps/public/848e3630-1650-11ec-8bc1-7d4a4822cc27
-  description: (optional) short description of the CodeSee Map
 contributionOverview: # (optional) Provide additional context to help contributors match well with your project
   mainLocation: India
   idealEffort: 1 PR a month

--- a/projects/roerohan/vscode-MongoSnippets-NodeJS.mdx
+++ b/projects/roerohan/vscode-MongoSnippets-NodeJS.mdx
@@ -14,9 +14,6 @@ currentlySeeking: # (optional) These fields are searchable and very helpful for 
   - Developers
   - Maintainers
   - Code Reviewers
-featuredMap: # (optional) A CodeSee Map to serve as a visual starting point for contributors
-  url: https://app.codesee.io/maps/public/848e3630-1650-11ec-8bc1-7d4a4822cc27
-  description: (optional) short description of the CodeSee Map
 contributionOverview: # (optional) Provide additional context to help contributors match well with your project
   mainLocation: India
   idealEffort: 1 PR a month


### PR DESCRIPTION
I noticed a couple of projects merged in still have the default OSS port map, so I went through the app and removed all the projects that have it.