### PR TITLE
Fix header link

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,5 +1,5 @@
 export const HOW_TO_LIST_PROJECT_URL =
-  "https://github.com/codesee-io/oss-port#how-to-list-your-own-project";
+  "https://github.com/codesee-io/oss-port#were-thrilled-to-have-you-in-port-its-super-easy-to-get-started-and-should-only-take-about-10-minutes";
 
 export const DISCORD =
 "https://discord.gg/JbAChX3a3a";


### PR DESCRIPTION
Due to a recent change to the readme, the link to List Your Project in the Header was no longer working.

This updated link will take users right to the instructions.