### PR TITLE
Improve the styling of markdown content

### DIFF
--- a/src/components/markdown/mdxElements.tsx
+++ b/src/components/markdown/mdxElements.tsx
@@ -24,4 +24,5 @@ export default {
   inlineCode: ({ children }) => (
     <code className="markdown-element">{children}</code>
   ),
+  pre: ({ children }) => <pre className="markdown-element">{children}</pre>,
 };

--- a/src/pages/resources.tsx
+++ b/src/pages/resources.tsx
@@ -21,7 +21,7 @@ const Resources = () => (
       >
         <div className="max-w-5xl mx-auto py-32 px-4">
           <div className="text-center max-w-xl ml-auto mr-auto text-black-500">
-            <h2 className="text-4xl font-accent leading-large">Resources</h2>
+            <h1 className="text-4xl font-accent leading-large">Resources</h1>
             <p className="my-4">
               All the info you need to onboard your crew at the OSS Port:
               showcase or find a project, make a map, or create a tour.
@@ -29,10 +29,7 @@ const Resources = () => (
           </div>
         </div>
       </section>
-      <section className="px-4 max-w-4xl mx-auto">
-        <h2 className="text-4xl font-accent leading-large text-black-500 mb-6">
-          Resources
-        </h2>
+      <section className="px-4 max-w-4xl mx-auto pb-20">
         <MDXProvider components={mdxComponents}>
           <HowToListYourProject />
         </MDXProvider>
@@ -44,7 +41,7 @@ const Resources = () => (
       >
         {/* Anchor tag to scroll to this form */}
         <a id="resources"></a>
-        <div className="max-w-5xl mx-auto py-16 px-4">
+        <div className="max-w-5xl mx-auto py-24 px-4">
           <div className="md:flex justify-center gap-6">
             <div className="max-w-3xl text-center">
               <h2 className="text-4xl mb-8 font-accent leading-large text-white">

--- a/src/resources/HowToListYourProject.mdx
+++ b/src/resources/HowToListYourProject.mdx
@@ -3,7 +3,7 @@
 
 ## How to list your project on OSS Port
 
-### We’re thrilled to have you in Port. It's super easy to get started, and should only take about 11 minutes.
+We’re thrilled to have you in Port. It's super easy to get started, and should only take about 11 minutes.
 
 ### Step 1: Getting up and running
 
@@ -33,10 +33,9 @@ For more information on the Github.dev editor, please [see their docs](https://d
    ```
 1. You can now view the project in your browser at http://localhost:8000
 
+## Contributing
 
-### Contributing
-
-#### Step 2: List your project
+### Step 2: List your project
 
 1. Follow the above setup steps
 1. Create your project's `.mdx` file
@@ -50,7 +49,7 @@ For more information on the Github.dev editor, please [see their docs](https://d
 1. Preview your changes by running `yarn start`
 1. When you're ready, open a PR!
 
-#### Step 3: Adding a CodeSee Map to your project listing
+### Step 3: Adding a CodeSee Map to your project listing
 
 Make it easier for contributors to onboard to your project! With a CodeSee Map, they can visualize the entire codebase, with features allowing them to explore system dependencies, add additional context to pull requests, and more.
 
@@ -67,19 +66,18 @@ featuredMap:
   description: Get a quick overview of the major areas of our repo
 ```
 
-
-That's it! 
+That's it!
 
 The CodeSee Map below is a good way to get familiar with the codebase:
 
 [<img alt="CodeSee Map preview" src="https://github.com/Codesee-io/oss-port/blob/main/docs/codebase-map.png?raw=true" width="500"></img>](https://app.codesee.io/maps/public/848e3630-1650-11ec-8bc1-7d4a4822cc27)
 
-#### Tag policy
+## Tag policy
 
 Final tags are up to the maintainers of OSS Port. Your tags may be modified for the benefit of the community and to improve discoverability.
 
 We use title-casing for tags. For example: "First Timer Friendly, Social Activism, C#, JavaScript".
 
-#### How to remove your project from OSS Port
+## How to remove your project from OSS Port
 
 Open a PR to remove your project folder from this repository.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -37,12 +37,25 @@ h3.markdown-element {
   margin-bottom: 12px;
 }
 
+h4.markdown-element {
+  @apply text-black-400;
+  font-weight: 500;
+  font-size: 15px;
+  line-height: 18px;
+  margin-bottom: 8px;
+}
+
 p.markdown-element,
 ul.markdown-element,
 ol.markdown-element {
   @apply text-black-300;
   font-size: 14px;
-  margin-bottom: 18px;
+  margin-bottom: 1rem;
+}
+
+/* reduce the vertical space between paragraphs */
+p.markdown-element + p.markdown-element {
+  margin-top: -0.75rem;
 }
 
 ul.markdown-element {
@@ -51,6 +64,21 @@ ul.markdown-element {
 
 ol.markdown-element {
   @apply list-decimal list-inside;
+}
+
+/* remove the vertical space between nested lists */
+ul.markdown-element ol,
+ol.markdown-element ol,
+ul.markdown-element ul,
+ol.markdown-element ul {
+  margin-bottom: 0;
+}
+
+/* specify the vertical space below pre elements inside of list items */
+ul.markdown-element pre,
+ol.markdown-element pre {
+  margin-bottom: 0.25rem;
+  margin-top: 0.25rem;
 }
 
 a.markdown-element {
@@ -73,6 +101,14 @@ code.markdown-element {
   margin: 0;
   font-size: 85%;
   border-radius: 5px;
+}
+
+pre.markdown-element {
+  @apply bg-black-50 text-black-500;
+  border-radius: 5px;
+  font-size: 85%;
+  margin-bottom: 1rem;
+  padding: 0.5rem 1rem;
 }
 
 /* Use this class on the direct parent of an anchor to display it on hover */


### PR DESCRIPTION
Styling improvements to the markdown parser:
- removed the vertical space between nested lists
- reduced the vertical space between paragraphs
- styled `<pre>` elements (code blocks)
- styled `<h4>` elements

I also updated the header elements on the `/resources` page. It was missing an `<h1>` and the steps didn't have the same header level. Open to feedback!

👉 https://deploy-preview-248--oss-port.netlify.app/resources 👈 