### PR TITLE
CODESEE-2183 Allow multiple maps on OSS page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,8 @@ public
 # Local Netlify folder
 .netlify
 
+# VS CODE PLUGIN
+.history/
+
 # Log
 yarn-error.log

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Now you're in the Github.dev editor! Feel free to hop ahead to [our contributing
 
 For more information on the Github.dev editor, please [see their docs](https://docs.github.com/en/codespaces/the-githubdev-web-based-editor).
 
-
 ### Local development (optional)
 
 1. Clone this repository to your machine
@@ -36,8 +35,6 @@ For more information on the Github.dev editor, please [see their docs](https://d
    ```
 
 1. You can now view the project in your browser at http://localhost:8000
-
-
 
 ## Contributing
 
@@ -72,8 +69,19 @@ featuredMap:
   description: Get a quick overview of the major areas of our repo
 ```
 
+If you would like to display multiple maps you can add an entry called "maps"
 
-That's it! 
+```
+maps:
+  - url: https://app.codesee.io/maps/public/848e3630-1650-11ec-8bc1-7d4a4822cc27
+    description: Get a quick visual overview of the major areas of our repo!
+    subTitle: devdocs
+  - url: https://app.codesee.io/maps/public/848e3630-1650-11ec-8bc1-7d4a4822cc27
+    description: Another map!
+    subTitle: testMap
+```
+
+That's it!
 
 The CodeSee Map below is a good way to get familiar with the codebase:
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -107,6 +107,11 @@ exports.createPages = async ({ actions, graphql, reporter, cache }) => {
               title
               url
             }
+            maps {
+              url
+              description
+              subTitle
+            }
           }
           parent {
             ... on File {
@@ -171,6 +176,19 @@ exports.createPages = async ({ actions, graphql, reporter, cache }) => {
       );
     }
 
+    // If the project has maps, load their metadata
+    let mapsMetadata = [];
+    if (node.frontmatter.maps?.length) {
+      for (let map of node.frontmatter.maps) {
+        const metaData = await getCodeSeeMapMetadata(
+          map.url,
+          cache
+        )
+
+        mapsMetadata.push(metaData)
+      }
+    }
+
     let helpfulness = 0;
     if (node.frontmatter.featuredMap?.url) {
       helpfulness += 5;
@@ -197,7 +215,7 @@ exports.createPages = async ({ actions, graphql, reporter, cache }) => {
 
     // tie breaker, count open issues:
     const openHelpIssues = (githubData.helpIssues || 0) + (githubData.hacktoberfestIssues || 0)
-    helpfulness += Math.min(0.9, openHelpIssues/10.0);
+    helpfulness += Math.min(0.9, openHelpIssues / 10.0);
 
     helpfulnessDataSet[node.slug] = helpfulness;
 
@@ -209,6 +227,7 @@ exports.createPages = async ({ actions, graphql, reporter, cache }) => {
         slug: node.slug,
         githubData,
         featuredMapMetadata,
+        mapsMetadata
       },
     });
   }

--- a/projects/Codesee-io/oss-port.mdx
+++ b/projects/Codesee-io/oss-port.mdx
@@ -22,6 +22,10 @@ avatar: ossport_avatar_circle.svg
 featuredMap:
   url: https://app.codesee.io/maps/public/848e3630-1650-11ec-8bc1-7d4a4822cc27
   description: Get a quick visual overview of the major areas of our repo!
+maps:
+  - url: https://app.codesee.io/maps/public/848e3630-1650-11ec-8bc1-7d4a4822cc27
+    description: Get a quick visual overview of the major areas of our repo!
+    subTitle: devdocs
 learnLinks:
   - title: Learn Gatsby
     url: https://www.gatsbyjs.com/

--- a/src/components/Maps.tsx
+++ b/src/components/Maps.tsx
@@ -1,0 +1,48 @@
+import React, { FunctionComponent, useContext } from "react";
+import ProjectContext from "./ProjectContext";
+import FormattedLink from "./markdown/FormattedLink";
+
+const Maps: FunctionComponent = () => {
+  const { frontmatter, mapsMetadata } = useContext(ProjectContext);
+  const maps = frontmatter.maps || []
+
+  if (!maps.length) return null;
+
+  return (
+    <section>
+      <h2 className="markdown-element mt-4">Our CodeSee Maps</h2>
+      <div className="md:flex md:space-x-4">
+        <ul className="md:flex gap-2 m-0 p-0">
+          {
+            maps.map(({ url, description, subTitle }, i) => (
+              <li key={`map-${i}`}
+                className="p-4 bg-white mb-2"
+                style={{
+                  width: 300
+                }}>
+                <div className="flex justify-center">
+                  <FormattedLink href={url} >
+                    <img
+                      src={mapsMetadata[i].thumbnail}
+                      width="260"
+                      height="150"
+                      className="object-cover rounded"
+                    />
+                  </FormattedLink>
+                </div>
+                <h3 className="text-black-500 font-bold mt-4">
+                  {description}
+                </h3>
+                {subTitle && <span className="text-black-500 text-sm font-normal" >
+                  {subTitle}
+                </span>}
+              </li>
+            ))
+          }
+        </ul>
+      </div>
+    </section >
+  )
+};
+
+export default Maps;

--- a/src/components/ProjectContext.tsx
+++ b/src/components/ProjectContext.tsx
@@ -11,6 +11,7 @@ const ProjectContext = createContext<{
   frontmatter: ProjectFrontmatter;
   githubData: GitHubData;
   featuredMapMetadata?: CodeSeeMapMetadata;
+  mapsMetadata?: CodeSeeMapMetadata[]
   organization: string;
 }>(null);
 

--- a/src/components/markdown/Contributing.tsx
+++ b/src/components/markdown/Contributing.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from "react";
+import Maps from "../Maps";
 import AnchorHeader from "./AnchorHeader";
 import HacktoberfestIssues from "./HacktoberfestIssues";
 import HelpWanted from "./HelpWanted";
@@ -11,6 +12,7 @@ const Contributing: FunctionComponent = ({ children }) => {
       <div className="md:flex md:space-x-4">
         <HelpWanted />
         <HacktoberfestIssues />
+        <Maps />
       </div>
     </div>
   );

--- a/src/templates/ProjectTemplate.tsx
+++ b/src/templates/ProjectTemplate.tsx
@@ -15,6 +15,7 @@ import Tag from "../components/Tag";
 import { ProjectFrontmatter } from "../types";
 import RootLayout from "../components/RootLayout";
 import ProjectAvatar from "../components/ProjectAvatar";
+import Maps from "../components/Maps";
 
 // Make some React components available globally in MDX files
 const mdxComponents = {
@@ -41,7 +42,7 @@ const ProjectTemplate: FunctionComponent<ProjectTemplateProps> = ({
   data: { projectData },
   pageContext,
 }) => {
-  const { githubData, featuredMapMetadata } = pageContext;
+  const { githubData, featuredMapMetadata, mapsMetadata } = pageContext;
 
   // Dynamically populate the tabs based on the existing sections
   const hasOverviewTab = projectData.body.includes("mdx(Overview,");
@@ -93,6 +94,7 @@ const ProjectTemplate: FunctionComponent<ProjectTemplateProps> = ({
             frontmatter: projectData.frontmatter,
             githubData,
             featuredMapMetadata,
+            mapsMetadata,
             organization: projectData.parent.organization,
           }}
         >
@@ -124,6 +126,11 @@ export const pageQuery = graphql`
         learnLinks {
           title
           url
+        }
+        maps {
+          url
+          description
+          subTitle
         }
         languages
         tags

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,11 @@ export type ProjectFrontmatter = {
     url: string;
     description: string;
   };
+  maps?: {
+    url: string;
+    description: string;
+    subTitle?: string;
+  }[];
   learnLinks?: {
     title?: string;
     url?: string;

--- a/src/utils/getCodeSeeMapMetadata.js
+++ b/src/utils/getCodeSeeMapMetadata.js
@@ -31,7 +31,7 @@ function getCodeSeeMapIdFromUrl(url) {
         return splitPath[1];
       }
     }
-  } catch (_) {}
+  } catch (_) { }
 
   return undefined;
 }


### PR DESCRIPTION
Updated `readme` 

If you would like to display multiple maps you can add an entry called "maps"

```
maps:
  - url: https://app.codesee.io/maps/public/848e3630-1650-11ec-8bc1-7d4a4822cc27
    description: Get a quick visual overview of the major areas of our repo!
    subTitle: devdocs
  - url: https://app.codesee.io/maps/public/848e3630-1650-11ec-8bc1-7d4a4822cc27
    description: Another map!
    subTitle: testMap
```
![OSS Port OSS Port 2021-11-03 at 2 41 26 PM](https://user-images.githubusercontent.com/5114910/140196989-34562f12-01a0-4913-9cb4-5be77d6228dc.jpg)

